### PR TITLE
Hierarchy Icons added

### DIFF
--- a/src/com.spoiledcat.git.api/Api/Application/ApplicationConfiguration.cs
+++ b/src/com.spoiledcat.git.api/Api/Application/ApplicationConfiguration.cs
@@ -8,5 +8,7 @@ namespace Unity.VersionControl.Git
         public const int DefaultGitTimeout = 5000;
         public static int WebTimeout { get; set; } = DefaultWebTimeout;
         public static int GitTimeout { get; set; } = DefaultGitTimeout;
+        public static bool AreHierarchyIconsTurnedOn { get; set; } = true;
+        public static bool AreHierarchyIconsIndented { get; set; } = false;
     }
 }

--- a/src/com.spoiledcat.git.api/Api/Application/ApplicationConfiguration.cs
+++ b/src/com.spoiledcat.git.api/Api/Application/ApplicationConfiguration.cs
@@ -10,5 +10,6 @@ namespace Unity.VersionControl.Git
         public static int GitTimeout { get; set; } = DefaultGitTimeout;
         public static bool AreHierarchyIconsTurnedOn { get; set; } = true;
         public static bool AreHierarchyIconsIndented { get; set; } = false;
+        public static int HierarchyIconsOffset { get; set; } = 0;
     }
 }

--- a/src/com.spoiledcat.git.api/Api/Application/ApplicationManagerBase.cs
+++ b/src/com.spoiledcat.git.api/Api/Application/ApplicationManagerBase.cs
@@ -37,6 +37,8 @@ namespace Unity.VersionControl.Git
             LogHelper.TracingEnabled = UserSettings.Get(Constants.TraceLoggingKey, false);
             ApplicationConfiguration.WebTimeout = UserSettings.Get(Constants.WebTimeoutKey, ApplicationConfiguration.WebTimeout);
             ApplicationConfiguration.GitTimeout = UserSettings.Get(Constants.GitTimeoutKey, ApplicationConfiguration.GitTimeout);
+            ApplicationConfiguration.AreHierarchyIconsTurnedOn = UserSettings.Get(Constants.HierarchyIconsVisibilityToggleKey, ApplicationConfiguration.AreHierarchyIconsTurnedOn);
+            ApplicationConfiguration.AreHierarchyIconsIndented = UserSettings.Get(Constants.HierarchyIconsIndentToggleKey, ApplicationConfiguration.AreHierarchyIconsIndented);
             progress.OnProgress += progressReporter.UpdateProgress;
         }
 

--- a/src/com.spoiledcat.git.api/Api/Application/ApplicationManagerBase.cs
+++ b/src/com.spoiledcat.git.api/Api/Application/ApplicationManagerBase.cs
@@ -39,6 +39,7 @@ namespace Unity.VersionControl.Git
             ApplicationConfiguration.GitTimeout = UserSettings.Get(Constants.GitTimeoutKey, ApplicationConfiguration.GitTimeout);
             ApplicationConfiguration.AreHierarchyIconsTurnedOn = UserSettings.Get(Constants.HierarchyIconsVisibilityToggleKey, ApplicationConfiguration.AreHierarchyIconsTurnedOn);
             ApplicationConfiguration.AreHierarchyIconsIndented = UserSettings.Get(Constants.HierarchyIconsIndentToggleKey, ApplicationConfiguration.AreHierarchyIconsIndented);
+            ApplicationConfiguration.HierarchyIconsOffset = UserSettings.Get(Constants.HierarchyIconsOffset, ApplicationConfiguration.HierarchyIconsOffset);
             progress.OnProgress += progressReporter.UpdateProgress;
         }
 

--- a/src/com.spoiledcat.git.api/Api/Helpers/Constants.cs
+++ b/src/com.spoiledcat.git.api/Api/Helpers/Constants.cs
@@ -11,6 +11,8 @@ namespace Unity.VersionControl.Git
         public const string TraceLoggingKey = "EnableTraceLogging";
         public const string WebTimeoutKey = "WebTimeout";
         public const string GitTimeoutKey = "GitTimeout";
+        public const string HierarchyIconsVisibilityToggleKey = "AreHierarchyIconsTurnedOn";
+        public const string HierarchyIconsIndentToggleKey = "IdentHierarchyIcons";
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
         public static readonly string[] Iso8601Formats = {

--- a/src/com.spoiledcat.git.api/Api/Helpers/Constants.cs
+++ b/src/com.spoiledcat.git.api/Api/Helpers/Constants.cs
@@ -13,6 +13,7 @@ namespace Unity.VersionControl.Git
         public const string GitTimeoutKey = "GitTimeout";
         public const string HierarchyIconsVisibilityToggleKey = "AreHierarchyIconsTurnedOn";
         public const string HierarchyIconsIndentToggleKey = "IdentHierarchyIcons";
+        public const string HierarchyIconsOffset = "HierarchyIconsOffset";
         public const string Iso8601Format = @"yyyy-MM-dd\THH\:mm\:ss.fffzzz";
         public const string Iso8601FormatZ = @"yyyy-MM-dd\THH\:mm\:ss\Z";
         public static readonly string[] Iso8601Formats = {

--- a/src/com.spoiledcat.git.ui/Editor/ApplicationManager.cs
+++ b/src/com.spoiledcat.git.ui/Editor/ApplicationManager.cs
@@ -34,6 +34,7 @@ namespace Unity.VersionControl.Git
             isBusy = false;
             LfsLocksModificationProcessor.Initialize(Environment, Platform);
             ProjectWindowInterface.Initialize(this);
+            HierarchyWindowInterface.Initialize();
             var window = Window.GetWindow();
             if (window != null)
                 window.InitializeWindow(this);

--- a/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
@@ -1,0 +1,39 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace Unity.VersionControl.Git
+{
+    [InitializeOnLoad]
+    public class HierarchyWindowInterface
+    {
+        static HierarchyWindowInterface()
+        {
+            EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyItemTryToDrawStatusIcon;
+        }
+
+        private static void OnHierarchyItemTryToDrawStatusIcon(int instanceID, Rect selectionRect)
+        {
+            GameObject hierarchyGO = EditorUtility.InstanceIDToObject(instanceID) as GameObject;
+            if (!hierarchyGO || hierarchyGO != PrefabUtility.GetNearestPrefabInstanceRoot(hierarchyGO))
+                return;
+
+            GameObject prefab = PrefabUtility.GetCorrespondingObjectFromSource(hierarchyGO);
+            if (!prefab)
+                return;
+
+            if (!AssetDatabase.TryGetGUIDAndLocalFileIdentifier(prefab, out string guid, out long localId))
+                return;
+
+            Texture2D texture = ProjectWindowInterface.GetStatusIconForAssetGUID(guid);
+            if (texture == null)
+                return;
+
+            // place the icon to the right of the list:
+            Rect r = new Rect(selectionRect);
+            r.x = r.width + 10;
+            r.width = 18;
+
+            GUI.Label(r, texture);
+        }
+    }
+}

--- a/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
@@ -14,11 +14,14 @@ namespace Unity.VersionControl.Git
 
         private static void OnHierarchyItemTryToDrawStatusIcon(int instanceID, Rect selectionRect)
         {
+            if (!ApplicationConfiguration.AreHierarchyIconsTurnedOn)
+                return;
+
             string guid;
             GameObject hierarchyGO = EditorUtility.InstanceIDToObject(instanceID) as GameObject;
-            if (!hierarchyGO)
+            if(!hierarchyGO)
             {
-                // if no Object has been returned by the InstanceIDToObject() method, then it is possible, that it is a scene
+                // if no Object has been returned by the InstanceIDToObject() method, then it is possible, that it is a Scene
                 string scenePath = "";
                 for (int i = 0; i < SceneManager.sceneCount; i++)
                 {
@@ -40,7 +43,7 @@ namespace Unity.VersionControl.Git
                 if (hierarchyGO != PrefabUtility.GetNearestPrefabInstanceRoot(hierarchyGO))
                     return;
 
-                GameObject prefab = PrefabUtility.GetCorrespondingObjectFromSource(hierarchyGO);
+                GameObject prefab = PrefabUtility.GetCorrespondingObjectFromOriginalSource(hierarchyGO);
                 if (!prefab)
                     return;
 
@@ -55,7 +58,7 @@ namespace Unity.VersionControl.Git
 
             // place the icon to the right of the list:
             Rect r = new Rect(selectionRect);
-            r.x = r.width + 10;
+            r.x = ApplicationConfiguration.AreHierarchyIconsIndented ? r.width + 10 : r.x = r.xMax - 40;
             r.width = 18;
 
             GUI.Label(r, texture);

--- a/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
@@ -57,7 +57,8 @@ namespace Unity.VersionControl.Git
 
             // place the icon to the right of the list:
             Rect r = new Rect(selectionRect);
-            r.x = ApplicationConfiguration.AreHierarchyIconsIndented ? r.width + 10 : r.x = r.xMax - 40;
+            r.x = ApplicationConfiguration.AreHierarchyIconsIndented ? r.width + 10 : r.xMax - 40;
+            r.x -= ApplicationConfiguration.HierarchyIconsOffset;
             r.width = 18;
 
             GUI.Label(r, texture);

--- a/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
@@ -4,10 +4,9 @@ using UnityEngine.SceneManagement;
 
 namespace Unity.VersionControl.Git
 {
-    [InitializeOnLoad]
     public class HierarchyWindowInterface
     {
-        static HierarchyWindowInterface()
+        public static void Initialize()
         {
             EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyItemTryToDrawStatusIcon;
         }

--- a/src/com.spoiledcat.git.ui/Editor/UI/SettingsView.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/SettingsView.cs
@@ -21,6 +21,8 @@ namespace Unity.VersionControl.Git
         private const string PrivacyTitle = "Privacy";
         private const string WebTimeoutLabel = "Timeout of web requests";
         private const string GitTimeoutLabel = "Timeout of git commands";
+        private const string HierarchyIconsVisiblityToggleLabel = "Show Git status icons in Hierarchy View";
+        private const string HierarchyIconsIndentToggleLabel = "Indent Git status icons in Hierarchy View";
         private const string EnableTraceLoggingLabel = "Enable Trace Logging";
         private const string MetricsOptInLabel = "Help us improve by sending anonymous usage data";
         private const string DefaultRepositoryRemoteName = "origin";
@@ -38,6 +40,8 @@ namespace Unity.VersionControl.Git
         [SerializeField] private UserSettingsView userSettingsView = new UserSettingsView();
         [SerializeField] private int webTimeout;
         [SerializeField] private int gitTimeout;
+        [SerializeField] private bool areHierarchyIconsTurnedOn;
+        [SerializeField] private bool areHierarchyIconsIndented;
 
         public override void InitializeView(IView parent)
         {
@@ -241,6 +245,33 @@ namespace Unity.VersionControl.Git
             {
                 ApplicationConfiguration.GitTimeout = gitTimeout;
                 Manager.UserSettings.Set(Constants.GitTimeoutKey, gitTimeout);
+            }
+
+            areHierarchyIconsTurnedOn = ApplicationConfiguration.AreHierarchyIconsTurnedOn;
+            EditorGUI.BeginChangeCheck();
+            {
+                areHierarchyIconsTurnedOn = EditorGUILayout.ToggleLeft(HierarchyIconsVisiblityToggleLabel, areHierarchyIconsTurnedOn);
+            }
+            if (EditorGUI.EndChangeCheck())
+            {
+                ApplicationConfiguration.AreHierarchyIconsTurnedOn = areHierarchyIconsTurnedOn;
+                Manager.UserSettings.Set(Constants.HierarchyIconsVisibilityToggleKey, areHierarchyIconsTurnedOn);
+                EditorApplication.RepaintHierarchyWindow();
+            }
+
+            if (areHierarchyIconsTurnedOn)
+            {
+                areHierarchyIconsIndented = ApplicationConfiguration.AreHierarchyIconsIndented;
+                EditorGUI.BeginChangeCheck();
+                {
+                    areHierarchyIconsIndented = EditorGUILayout.ToggleLeft(HierarchyIconsIndentToggleLabel, areHierarchyIconsIndented);
+                }
+                if (EditorGUI.EndChangeCheck())
+                {
+                    ApplicationConfiguration.AreHierarchyIconsIndented = areHierarchyIconsIndented;
+                    Manager.UserSettings.Set(Constants.HierarchyIconsIndentToggleKey, areHierarchyIconsIndented);
+                    EditorApplication.RepaintHierarchyWindow();
+                }
             }
         }
 

--- a/src/com.spoiledcat.git.ui/Editor/UI/SettingsView.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/SettingsView.cs
@@ -23,6 +23,7 @@ namespace Unity.VersionControl.Git
         private const string GitTimeoutLabel = "Timeout of git commands";
         private const string HierarchyIconsVisiblityToggleLabel = "Show Git status icons in Hierarchy View";
         private const string HierarchyIconsIndentToggleLabel = "Indent Git status icons in Hierarchy View";
+        private const string HierarchyIconsOffsetLabel = "Hierarchy icons X offset";
         private const string EnableTraceLoggingLabel = "Enable Trace Logging";
         private const string MetricsOptInLabel = "Help us improve by sending anonymous usage data";
         private const string DefaultRepositoryRemoteName = "origin";
@@ -42,6 +43,7 @@ namespace Unity.VersionControl.Git
         [SerializeField] private int gitTimeout;
         [SerializeField] private bool areHierarchyIconsTurnedOn;
         [SerializeField] private bool areHierarchyIconsIndented;
+        [SerializeField] private int hierarchyIconsOffset;
 
         public override void InitializeView(IView parent)
         {
@@ -261,6 +263,7 @@ namespace Unity.VersionControl.Git
 
             if (areHierarchyIconsTurnedOn)
             {
+                EditorGUI.indentLevel++;
                 areHierarchyIconsIndented = ApplicationConfiguration.AreHierarchyIconsIndented;
                 EditorGUI.BeginChangeCheck();
                 {
@@ -272,6 +275,19 @@ namespace Unity.VersionControl.Git
                     Manager.UserSettings.Set(Constants.HierarchyIconsIndentToggleKey, areHierarchyIconsIndented);
                     EditorApplication.RepaintHierarchyWindow();
                 }
+
+                hierarchyIconsOffset = ApplicationConfiguration.HierarchyIconsOffset;
+                EditorGUI.BeginChangeCheck();
+                {
+                    hierarchyIconsOffset = EditorGUILayout.IntSlider(HierarchyIconsOffsetLabel, hierarchyIconsOffset, -30, 200);
+                }
+                if (EditorGUI.EndChangeCheck())
+                {
+                    ApplicationConfiguration.HierarchyIconsOffset = hierarchyIconsOffset;
+                    Manager.UserSettings.Set(Constants.HierarchyIconsOffset, hierarchyIconsOffset);
+                    EditorApplication.RepaintHierarchyWindow();
+                }
+                EditorGUI.indentLevel--;
             }
         }
 


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Hierarchy Icons has been added! They show the same icons as in the Project View for prefabs.
![image](https://github.com/spoiledcat/git-for-unity/assets/48469205/72bc7c20-6842-43cf-979b-0a9d5cbb8eb5)
I have refactored `ProjectWindowInterace` class by extracting `GetStatusIconForAssetGUID(guid)` method from it, so I can get an icon for an asset GUID easily, without copying code.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

I was thinking about adding such icons next to a prefab name in prefab mode too, but that's maybe for the future, as it is easier now after my `ProjectWindowInterace` class refactor.
![image](https://github.com/spoiledcat/git-for-unity/assets/48469205/92998b98-cb85-4e38-8782-78775e50a383)

### Benefits

<!-- What benefits will be realized by the code change? -->
It is much easier to see now, which prefabs are currently locked. It is not needed to look at Locks window or to look at Project View before modifying any prefab, so it is harder to make changes in locked files by mistake.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
It is possible for the icons to be drawn on prefabs names. But you need to have a very long prefab's name or a very narrow Hierarchy window. For me, it is a small price to pay for less mistakes made by developers.
![image](https://github.com/spoiledcat/git-for-unity/assets/48469205/63e090a3-c2a3-4d13-8653-fa690afe696c)

### Applicable Issues

<!-- Enter any applicable Issues here -->
Before this change, checking if a prefab is locked was easy from scene/prefab view, but demanded additional action (finding the prefab in a Project View or opening a Locks window and comparing a list of locks with your prefab). Now, you see this info in Hierarchy window, which means you can see if the prefab is locked without additional actions, when you modify the prefab from Scene View.