### PR TITLE
fix crash

### DIFF
--- a/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
@@ -69,7 +69,7 @@ namespace Unity.VersionControl.Git.UI
             GitStatusEntry? gitStatusEntry = null;
             GitFileStatus status = GitFileStatus.None;
 
-            if (index >= 0)
+            if (index >= 0 && index < entries.Count)
             {
                 gitStatusEntry = entries[index];
                 status = gitStatusEntry.Value.Status;


### PR DESCRIPTION
### Description of the Change


Hi, thank you for creating and maintaining this tool! I've just started using it in my own Unity project, and it's been super useful! 

I forked the branch because I sometimes hit a crash after committing my changes. The problem was an out of range exception in ProjectWindowInterface.cs. So, I just added a checked to make sure that this particular index value was within the upper bound as well.


### Alternate Designs

It's a pretty limited and straightforward fix. I don't see the need for an alternative.

### Benefits

This change avoids a potential crash.

### Possible Drawbacks

I can't think of any. I've been testing this change for a few days now and I haven't hit any knock-on issues.

### Applicable Issues

I couldn't find any.
