### PR TITLE
address bug where StreamExtensions.invokeLoadImage is null in unity6.2

### DIFF
--- a/src/com.spoiledcat.git.ui/Editor/Misc/Utility.cs
+++ b/src/com.spoiledcat.git.ui/Editor/Misc/Utility.cs
@@ -104,7 +104,7 @@ namespace Unity.VersionControl.Git
                 if (t != null)
                 {
                     // looking for ImageConversion.LoadImage(this Texture2D tex, byte[] data)
-                    loadImage = typeof(Texture2D).FindMethod("LoadImage", 2, new[] {null, typeof(byte[])});
+                    loadImage = t.FindMethod("LoadImage", 2, new[] {null, typeof(byte[])});
                     if (loadImage != null)
                     {
                         invokeLoadImage = (tex, ms) => {


### PR DESCRIPTION
### Description of the Change
updates the constructor to use value `t` that was populated with ImageConversion on line 101 so LoadImage can be found, typeof(Texture2D) does not have LoadImage so the `invokeLoadImage` delegate ends up being null and causes an exception when the git window attempts to draw