### PR TITLE
Fix for Unity 6.5 deprecating InstanceID and throwing a compiler error on it's usage

### DIFF
--- a/src/com.spoiledcat.git.ui/Editor/Misc/Styles.cs
+++ b/src/com.spoiledcat.git.ui/Editor/Misc/Styles.cs
@@ -103,6 +103,7 @@ namespace Unity.VersionControl.Git.UI
 
         public static Texture2D GetFileStatusIcon(GitFileStatus status, bool isLocked)
         {
+#if !GIT_FOR_UNITY_DISABLE_LOCKING_UI
             if (isLocked)
             {
                 switch (status)
@@ -114,7 +115,7 @@ namespace Unity.VersionControl.Git.UI
                         return Utility.GetIcon("locked-by-person");
                 }
             }
-
+#endif
             switch (status)
             {
                 case GitFileStatus.Modified:

--- a/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
@@ -13,26 +13,26 @@ namespace Unity.VersionControl.Git.UI
         public static void Initialize()
         {
             iconCache = new Dictionary<int, Texture2D>();
-            EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyItemTryToDrawStatusIcon;
+            EditorApplication.hierarchyWindowItemByEntityIdOnGUI += OnHierarchyItemTryToDrawStatusIcon;
         }
 
-        private static void OnHierarchyItemTryToDrawStatusIcon(int instanceID, Rect selectionRect)
+        private static void OnHierarchyItemTryToDrawStatusIcon(EntityId entityId, Rect selectionRect)
         {
             if (!ApplicationConfiguration.HierarchyIconsEnabled)
                 return;
 
-            if (!iconCache.TryGetValue(instanceID, out Texture2D texture))
+            if (!iconCache.TryGetValue(entityId.GetHashCode(), out Texture2D texture))
             {
                 string guid = null;
-                GameObject hierarchyGO = EditorUtility.InstanceIDToObject(instanceID) as GameObject;
+                GameObject hierarchyGO = EditorUtility.EntityIdToObject(entityId) as GameObject;
                 if (!hierarchyGO)
                 {
-                    // if no Object has been returned by the InstanceIDToObject() method, then it is possible, that it is a Scene
+                    // if no Object has been returned by the EntityIDToObject() method, then it is possible, that it is a Scene
                     string scenePath = "";
                     for (int i = 0; i < SceneManager.sceneCount; i++)
                     {
                         Scene scene = SceneManager.GetSceneAt(i);
-                        if (scene.GetHashCode() == instanceID)
+                        if (scene.GetHashCode() == entityId.GetHashCode())
                         {
                             scenePath = scene.path;
                             break;
@@ -41,7 +41,7 @@ namespace Unity.VersionControl.Git.UI
 
                     if (string.IsNullOrEmpty(scenePath))
                     {
-                        iconCache.Add(instanceID, null);
+                        iconCache.Add(entityId.GetHashCode(), null);
                         return;
                     }
 
@@ -65,7 +65,7 @@ namespace Unity.VersionControl.Git.UI
                     texture = ProjectWindowInterface.GetStatusIconForAssetGUID(guid);
                 }
 
-                iconCache.Add(instanceID, texture);
+                iconCache.Add(entityId.GetHashCode(), texture);
             }
 
             if (texture == null)

--- a/src/com.spoiledcat.git.ui/Editor/UI/LfsLocksModificationProcessor.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/LfsLocksModificationProcessor.cs
@@ -78,14 +78,14 @@ namespace Unity.VersionControl.Git.UI
             }
         }
 
-        private static void UserMayHaveChanged()
+        private static void UserMayHaveChanged(CacheUpdateEvent cacheUpdateEvent)
         {
             //loggedInUser = platform.Keychain.Connections.Select(x => x.Username).FirstOrDefault();
         }
 
         private static bool IsLockedBySomeoneElse(GitLock? lck)
         {
-            return lck.HasValue && !lck.Value.Owner.Name.Equals(loggedInUser);
+            return lck.HasValue && !lck.Value.Owner.Name.Equals(environment.User.Name);
         }
 
         private static bool IsLockedBySomeoneElse(string assetPath)

--- a/src/com.spoiledcat.git.ui/Editor/UI/LocksView.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/LocksView.cs
@@ -446,7 +446,7 @@ namespace Unity.VersionControl.Git.UI
                     entry =>
                     {
                         var menu = new GenericMenu();
-                        if (entry.Owner.Name == currentUsername)
+                        if (entry.Owner.Name == Environment.User.Name)
                         {
                             menu.AddItem(unlockFileMenuContent, false, UnlockSelectedEntry);
                         }

--- a/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
@@ -272,7 +272,7 @@ namespace Unity.VersionControl.Git.UI
             SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
-            return locks.Any(x => repositoryPath == x.Path && (!isLockedByCurrentUser || x.Owner.Name == currentUsername));
+            return locks.Any(x => repositoryPath == x.Path && (!isLockedByCurrentUser || x.Owner.Name == Platform.Environment.User.Name));
         }
 
         private static ITask CreateUnlockObjectTask(Object selected, bool force)

--- a/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
@@ -37,6 +37,7 @@ namespace Unity.VersionControl.Git.UI
 
         public static void Initialize(IApplicationManager theManager)
         {
+#if !GIT_FOR_UNITY_DISABLE_LOCKING_UI
             EditorApplication.projectWindowItemOnGUI -= OnProjectWindowItemGUI;
             EditorApplication.projectWindowItemOnGUI += OnProjectWindowItemGUI;
 
@@ -52,6 +53,7 @@ namespace Unity.VersionControl.Git.UI
                 Repository.CurrentRemoteChanged += RepositoryOnCurrentRemoteChanged;
                 ValidateCachedData();
             }
+#endif
         }
 
         public static Texture2D GetStatusIconForAssetGUID(string guid)
@@ -162,7 +164,7 @@ namespace Unity.VersionControl.Git.UI
 
             currentUsername = username;
         }
-
+#if !GIT_FOR_UNITY_DISABLE_LOCKING_UI
         [MenuItem(AssetsMenuRequestLock, true, 10000)]
         private static bool ContextMenu_CanLock()
         {
@@ -216,7 +218,7 @@ namespace Unity.VersionControl.Git.UI
         {
             RunLockUnlock(EntryPoint.ApplicationManager.TaskManager, IsObjectLocked, x => CreateUnlockObjectTask(x, true), Localization.ReleaseLockActionTitle, "Failed to unlock: no permissions");
         }
-
+#endif
         private static void RunLockUnlock(ITaskManager taskManager, Func<Object, bool> selector, Func<Object, ITask> creator, string title, string errorMessage)
         {
             isBusy = true;

--- a/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
@@ -244,7 +244,7 @@ namespace Unity.VersionControl.Git.UI
             if (selected == null)
                 return false;
 
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             var alreadyLocked = locks.Any(x => repositoryPath == x.Path);
@@ -269,7 +269,7 @@ namespace Unity.VersionControl.Git.UI
             if (selected == null)
                 return false;
 
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             return locks.Any(x => repositoryPath == x.Path && (!isLockedByCurrentUser || x.Owner.Name == currentUsername));
@@ -277,7 +277,7 @@ namespace Unity.VersionControl.Git.UI
 
         private static ITask CreateUnlockObjectTask(Object selected, bool force)
         {
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             var task = Repository.ReleaseLock(repositoryPath, force);
@@ -287,7 +287,7 @@ namespace Unity.VersionControl.Git.UI
 
         private static ITask CreateLockObjectTask(Object selected)
         {
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             var task = Repository.RequestLock(repositoryPath);

--- a/src/com.spoiledcat.git.ui/Editor/UI/Window.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/Window.cs
@@ -560,7 +560,9 @@ namespace Unity.VersionControl.Git.UI
                     if (HasRepository)
                     {
                         changeTab = TabButton(SubTab.Changes, Localization.ChangesTitle, changeTab);
+#if !GIT_FOR_UNITY_DISABLE_LOCKING_UI
                         changeTab = TabButton(SubTab.Locks, Localization.LocksTitle, changeTab);
+#endif
                         changeTab = TabButton(SubTab.History, Localization.HistoryTitle, changeTab);
                         changeTab = TabButton(SubTab.Branches, Localization.BranchesTitle, changeTab);
                     }


### PR DESCRIPTION
Unity 6.5 deprecates `InstanceID`, replacing it with `EntityID`.

### Description of the Change

Unity 6.5 treats the usage of the `InstanceID` data type as a compiler error and removes the associated API calls entirely, replacing it with the `EntityId` type. Details on this change can be found on the list of breaking changes in Unity 6.5 under "Removal of temporary `InstanceID` type": [https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-03-27/1694205](https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-03-27/1694205)

The code changes are swapping `InstanceID` with `EntityId`, swapping the appropriate methods (for which there are 1:1 equivalents), and using the `EntityId`'s hashcode as a dictionary key (stored as an int) instead of casting it directly to an int like was being done previously to the `InstanceID` (which Unity documentation says is not officially supported functionality).

### Alternate Designs

This is just an update to bring this package in compliance with new Unity requirements, so no design changes were considered. Minimal changes were made to return this to functionality and remove compiler errors.

### Benefits

The package will now work on Unity 6.5.

### Possible Drawbacks

This may break older versions of Unity. According to Unity's [page on breaking changes in Unity 6.5](https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-03-27/1694205) this should work at least as far back as version 6.2. From what I can tell, `InstanceID` shouldn't actually function before that point, so I think this is safe. I haven't tested it on any version but 6.5 though.

### Applicable Issues

None.
