### PR TITLE
Replaced instanceID with entityId

### DIFF
--- a/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/HierarchyWindowInterface.cs
@@ -13,26 +13,26 @@ namespace Unity.VersionControl.Git.UI
         public static void Initialize()
         {
             iconCache = new Dictionary<int, Texture2D>();
-            EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyItemTryToDrawStatusIcon;
+            EditorApplication.hierarchyWindowItemByEntityIdOnGUI += OnHierarchyItemTryToDrawStatusIcon;
         }
 
-        private static void OnHierarchyItemTryToDrawStatusIcon(int instanceID, Rect selectionRect)
+        private static void OnHierarchyItemTryToDrawStatusIcon(EntityId entityId, Rect selectionRect)
         {
             if (!ApplicationConfiguration.HierarchyIconsEnabled)
                 return;
 
-            if (!iconCache.TryGetValue(instanceID, out Texture2D texture))
+            if (!iconCache.TryGetValue(entityId.GetHashCode(), out Texture2D texture))
             {
                 string guid = null;
-                GameObject hierarchyGO = EditorUtility.InstanceIDToObject(instanceID) as GameObject;
+                GameObject hierarchyGO = EditorUtility.EntityIdToObject(entityId) as GameObject;
                 if (!hierarchyGO)
                 {
-                    // if no Object has been returned by the InstanceIDToObject() method, then it is possible, that it is a Scene
+                    // if no Object has been returned by the EntityIDToObject() method, then it is possible, that it is a Scene
                     string scenePath = "";
                     for (int i = 0; i < SceneManager.sceneCount; i++)
                     {
                         Scene scene = SceneManager.GetSceneAt(i);
-                        if (scene.GetHashCode() == instanceID)
+                        if (scene.GetHashCode() == entityId.GetHashCode())
                         {
                             scenePath = scene.path;
                             break;
@@ -41,7 +41,7 @@ namespace Unity.VersionControl.Git.UI
 
                     if (string.IsNullOrEmpty(scenePath))
                     {
-                        iconCache.Add(instanceID, null);
+                        iconCache.Add(entityId.GetHashCode(), null);
                         return;
                     }
 
@@ -65,7 +65,7 @@ namespace Unity.VersionControl.Git.UI
                     texture = ProjectWindowInterface.GetStatusIconForAssetGUID(guid);
                 }
 
-                iconCache.Add(instanceID, texture);
+                iconCache.Add(entityId.GetHashCode(), texture);
             }
 
             if (texture == null)

--- a/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
+++ b/src/com.spoiledcat.git.ui/Editor/UI/ProjectWindowInterface.cs
@@ -244,7 +244,7 @@ namespace Unity.VersionControl.Git.UI
             if (selected == null)
                 return false;
 
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             var alreadyLocked = locks.Any(x => repositoryPath == x.Path);
@@ -269,7 +269,7 @@ namespace Unity.VersionControl.Git.UI
             if (selected == null)
                 return false;
 
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             return locks.Any(x => repositoryPath == x.Path && (!isLockedByCurrentUser || x.Owner.Name == currentUsername));
@@ -277,7 +277,7 @@ namespace Unity.VersionControl.Git.UI
 
         private static ITask CreateUnlockObjectTask(Object selected, bool force)
         {
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             var task = Repository.ReleaseLock(repositoryPath, force);
@@ -287,7 +287,7 @@ namespace Unity.VersionControl.Git.UI
 
         private static ITask CreateLockObjectTask(Object selected)
         {
-            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetInstanceID()).ToSPath();
+            SPath assetPath = AssetDatabase.GetAssetPath(selected.GetEntityId()).ToSPath();
             SPath repositoryPath = assetPath.RelativeToRepository(manager.Environment);
 
             var task = Repository.RequestLock(repositoryPath);


### PR DESCRIPTION
Unity 6.5 deprecates `InstanceID`, replacing it with `EntityID`.

### Description of the Change

Unity 6.5 treats the usage of the `InstanceID` data type as a compiler error and removes the associated API calls entirely, replacing it with the `EntityId` type. Details on this change can be found on the list of breaking changes in Unity 6.5 under "Removal of temporary `InstanceID` type": [https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-03-27/1694205](https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-03-27/1694205)

The code changes are swapping `InstanceID` with `EntityId`, swapping the appropriate methods (for which there are 1:1 equivalents), and using the `EntityId`'s hashcode as a dictionary key (stored as an int) instead of casting it directly to an int like was being done previously to the `InstanceID` (which Unity documentation says is not officially supported functionality).

### Alternate Designs

This is just an update to bring this package in compliance with new Unity requirements, so no design changes were considered. Minimal changes were made to return this to functionality and remove compiler errors.

### Benefits

The package will now work on Unity 6.5.

### Possible Drawbacks

This may break older versions of Unity. According to Unity's [page on breaking changes in Unity 6.5](https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-03-27/1694205) this should work at least as far back as version 6.2. From what I can tell, `InstanceID` shouldn't actually function before that point, so I think this is safe. I haven't tested it on any version but 6.5 though.

### Applicable Issues

None.
